### PR TITLE
Multisite upload dir compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Items to ignore when downloading a zip
+
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+README.md export-ignore
+/.vscode/ export-ignore
+/.github/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/includes/class-local-google-fonts-admin.php
+++ b/includes/class-local-google-fonts-admin.php
@@ -132,8 +132,8 @@ class LGF_Admin {
 
 	public function get_font_info( $src, $handle = null ) {
 
-		$folder     = WP_CONTENT_DIR . '/uploads/fonts';
-		$folder_url = WP_CONTENT_URL . '/uploads/fonts';
+		$upload_dir = wp_get_upload_dir();
+		$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
 
 		// remove 'ver' query arg as it is added by WP
 		$src = preg_replace('/&ver=([^&]+)/', '', $src);

--- a/includes/class-local-google-fonts.php
+++ b/includes/class-local-google-fonts.php
@@ -89,8 +89,9 @@ class LGF {
 			)
 		);
 
-		$folder     = WP_CONTENT_DIR . '/uploads/fonts';
-		$folder_url = WP_CONTENT_URL . '/uploads/fonts';
+		$upload_dir = wp_get_upload_dir();
+		$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
+		$folder_url = $upload_dir['error'] ? WP_CONTENT_URL . '/uploads/fonts' : $upload_dir['baseurl'] . '/fonts';
 
 		$new_src = $folder_url . '/' . $id . '/font.css';
 		$new_dir = $folder . '/' . $id . '/font.css';
@@ -188,8 +189,9 @@ class LGF {
 
 		$id = md5( $src );
 
-		$folder     = WP_CONTENT_DIR . '/uploads/fonts';
-		$folder_url = WP_CONTENT_URL . '/uploads/fonts';
+		$upload_dir = wp_get_upload_dir();
+		$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
+		$folder_url = $upload_dir['error'] ? WP_CONTENT_URL . '/uploads/fonts' : $upload_dir['baseurl'] . '/fonts';
 
 		$stylesheet     = $folder . '/' . $id . '/font.css';
 		$stylesheet_url = $folder_url . '/' . $id . '/font.css';
@@ -238,7 +240,8 @@ class LGF {
 
 
 	public function clear() {
-		$folder = WP_CONTENT_DIR . '/uploads/fonts';
+		$upload_dir = wp_get_upload_dir();
+		$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
 		if ( is_dir( $folder ) ) {
 			$WP_Filesystem = $this->wp_filesystem();
 			$WP_Filesystem->delete( $folder, true );
@@ -252,7 +255,8 @@ class LGF {
 	}
 
 	public function remove_set( $id = null ) {
-		$folder = WP_CONTENT_DIR . '/uploads/fonts';
+		$upload_dir = wp_get_upload_dir();
+		$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
 		if ( ! is_null( $id ) ) {
 			$folder .= '/' . basename( $id );
 		}

--- a/local-google-fonts.php
+++ b/local-google-fonts.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Local Google Fonts
 Description: Host your used Google fonts on your server and make your site GDPR compliant.
-Version: 0.18
+Version: 0.19
 Author: EverPress
 Author URI: https://everpress.co
 License: GPLv2 or later

--- a/views/settings.php
+++ b/views/settings.php
@@ -1,10 +1,10 @@
 <?php
 
-
 $buffer = get_option( 'local_google_fonts_buffer', array() );
 
-$folder     = WP_CONTENT_DIR . '/uploads/fonts';
-$folder_url = WP_CONTENT_URL . '/uploads/fonts';
+$upload_dir = wp_get_upload_dir();
+$folder     = $upload_dir['error'] ? WP_CONTENT_DIR . '/uploads/fonts' : $upload_dir['basedir'] . '/fonts';
+$folder_url = $upload_dir['error'] ? WP_CONTENT_URL . '/uploads/fonts' : $upload_dir['baseurl'] . '/fonts';
 $count      = count( $buffer );
 
 if ( ! $count ) :
@@ -24,7 +24,7 @@ if ( ! $count ) :
 
 		?>
 		<?php submit_button(); ?>
-		
+
 	<hr>
 	<h2><?php printf( esc_html__( _n( '%d Google font source found on your site.', '%d Google font sources found on your site.', $count, 'local-google-fonts' ) ), $count ); ?></h2>
 
@@ -64,13 +64,13 @@ if ( ! $count ) :
 					<td>
 						<p class="code">
 						<?php foreach ( $font->variants as $variant ) : ?>
-								<span class="variant"><?php printf( '%s %s', $variant->fontStyle, $variant->fontWeight ); ?></span> 
+								<span class="variant"><?php printf( '%s %s', $variant->fontStyle, $variant->fontWeight ); ?></span>
 						<?php endforeach ?>
 						</p>
 						<?php $active_subsets = isset( $data['subsets'] ) ? $data['subsets'][ $font->id ] : array_keys( array_filter( (array) $font->subsetMap ) ); ?>
 						<p><strong><?php esc_html_e( 'Subsets', 'local-google-fonts' ); ?></strong><br>
 						<?php foreach ( $font->subsetMap as $subset => $is_active ) : ?>
-							<label title="<?php printf( esc_attr__( 'Load %s subset with this font', 'local-google-fonts' ), $subset ); ?>" class="subset"><input type="checkbox" name="subsets[<?php echo esc_attr( $data['handle'] ); ?>][<?php echo esc_attr( $font->id ); ?>][]" value="<?php echo esc_attr( $subset ); ?>" <?php checked( in_array( $subset, $active_subsets ) ); ?>> <?php echo esc_html( $subset ); ?> </label> 
+							<label title="<?php printf( esc_attr__( 'Load %s subset with this font', 'local-google-fonts' ), $subset ); ?>" class="subset"><input type="checkbox" name="subsets[<?php echo esc_attr( $data['handle'] ); ?>][<?php echo esc_attr( $font->id ); ?>][]" value="<?php echo esc_attr( $subset ); ?>" <?php checked( in_array( $subset, $active_subsets ) ); ?>> <?php echo esc_html( $subset ); ?> </label>
 						<?php endforeach ?>
 						</p>
 						<details>
@@ -89,8 +89,8 @@ if ( ! $count ) :
 									<?php else : ?>
 										<code><?php esc_html_e( 'Local', 'local-google-fonts' ); ?>: <?php echo esc_html( basename( $file ) ); ?></code>
 										<strong class="wp-ui-text-notification" title="<?php esc_attr_e( 'not loaded, served from Google servers', 'local-google-fonts' ); ?>">✕</strong>
-									<?php endif; ?>	
-									</li>								
+									<?php endif; ?>
+									</li>
 									<li><code><?php esc_html_e( 'Remote', 'local-google-fonts' ); ?>: <?php echo esc_url( $variant->{$ext} ); ?></code></li>
 									</ul>
 								<?php endforeach; ?>
@@ -105,13 +105,13 @@ if ( ! $count ) :
 						<?php else : ?>
 							<?php printf( '%s %s', '<strong class="wp-ui-text-notification">✕</strong>', esc_html__( 'not loaded, served from Google servers', 'local-google-fonts' ) ); ?>
 						<?php endif; ?>
-					
+
 					</td>
 
 				</tr>
 			<?php endforeach ?>
 			</tbody>
-		</table>		
+		</table>
 		<p>
 				<?php if ( is_dir( $folder . '/' . $data['id'] ) ) : ?>
 			<button class="host-locally button button-primary" name="hostlocal" value="<?php echo esc_attr( $data['handle'] ); ?>"><?php esc_html_e( 'Reload Fonts', 'local-google-fonts' ); ?></button>
@@ -126,8 +126,8 @@ if ( ! $count ) :
 	<hr>
 		<p class="textright">
 			<button class="host-locally button button-link-delete" name="flush" value="1"><?php esc_html_e( 'Remove all stored data', 'local-google-fonts' ); ?></button>
-		</p>			
-	<?php submit_button(); ?>							
+		</p>
+	<?php submit_button(); ?>
 
 		</form>
 	</section>


### PR DESCRIPTION
This resolves conflicts arising on WP Multisite when sites use the same themes and/or fonts but want different plugin settings.

The fonts dir/url, when running on a sub-site, is now in the sub-site upload folder instead of the main site. Uses wp_get_upload_dir() which uses on WP_Cache, so it should not have a big impact.

Tested on WP 6.0 (single- & multisite) and 6.1 (singlesite).