### PR TITLE
Don't show admin message when plugin is network-activated

### DIFF
--- a/includes/class-local-google-fonts.php
+++ b/includes/class-local-google-fonts.php
@@ -250,6 +250,12 @@ class LGF {
 		if ( get_current_screen()->id == 'settings_page_lgf-settings' ) {
 			return;
 		}
+		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			include ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		if ( strpos( LGF_PLUGIN_FILE, 'mu-plugins/' ) || is_plugin_active_for_network( plugin_basename( LGF_PLUGIN_FILE ) ) ) {
+			return;
+		}
 		?>
 	<div class="notice notice-info">
 		<p><?php printf( esc_html__( 'Thanks for using Local Google Fonts. Please check the %s.', 'local-google-fonts' ), '<a href="' . admin_url( 'options-general.php?page=lgf-settings' ) . '">' . esc_html__( 'settings page', 'local-google-fonts' ) . '</a>' ); ?></p>


### PR DESCRIPTION
Resolves #14

## Description

Adds extra check for network-activated or must-use plugin to short-circuit admin message.