### PR TITLE
Allow regeneration of font files on every request

### DIFF
--- a/includes/class-local-google-fonts-admin.php
+++ b/includes/class-local-google-fonts-admin.php
@@ -114,6 +114,14 @@ class LGF_Admin {
 		<p class="description">
 			<?php esc_html_e( 'If you check this option discovered fonts will get loaded automatically.', 'local-google-fonts' ); ?>
 		</p>
+		<p>
+			<label><input type="checkbox" value="1" name="local_google_fonts[always_regenerate]" <?php checked( isset( $options['always_regenerate'] ) ); ?>>
+				<?php esc_html_e( 'Always regenerate font files', 'local-google-fonts' ); ?>
+			</label>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'If you check this option, the font CSS will be regenerated at every request. This might be required if you point multiple domains to the same WordPress instance.', 'local-google-fonts' ); ?>
+		</p>
 		<?php
 	}
 

--- a/includes/class-local-google-fonts.php
+++ b/includes/class-local-google-fonts.php
@@ -188,7 +188,9 @@ class LGF {
 		$stylesheet     = $folder . '/' . $id . '/font.css';
 		$stylesheet_url = $folder_url . '/' . $id . '/font.css';
 
-		if ( ! file_exists( $stylesheet ) ) {
+		$options = get_option( 'local_google_fonts' );
+
+		if ( isset( $options['always_regenerate'] ) || !file_exists( $stylesheet ) ) {
 
 			// do not load on customizer preview.
 			if ( is_customize_preview() ) {
@@ -208,7 +210,6 @@ class LGF {
 
 			update_option( 'local_google_fonts_buffer', $buffer );
 
-			$options = get_option( 'local_google_fonts' );
 			if ( ! isset( $options['auto_load'] ) ) {
 				return $org;
 			}


### PR DESCRIPTION
Resolves an issue we had.

## Description

We have a WordPress instance that has multiple domains pointing to it.
This is done by updating the `WP_SITEURL` and `WP_HOME` variables at request time in the `wp-config.php` causing WordPress to think that it's running under that specific domain.

This plugin in not compatible with that in the sense that it only regenerates the stylesheets when the stylesheets don't exist, causing the URL in the CSS file to be set to one of the domains (the one that was used to generate the stylesheet the first time).

I've solved this by adding a "Always regenerate" checkbox causing the "file exists" check to be ignored and the stylesheet to be generated at every request and thus for the correct URL.

## Testing Instructions

1. Configure a WordPress instance to handle two domains (that are configured in your DNS):
```php
if($_SERVER['HTTP_HOST'] == 'somedomain.example.com' || $_SERVER['HTTP_host'] == 'someotherdomain.example.com'){
    define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
    define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST']);
}
```
2. Generate the local google fonts on using one of the domains
3. Visit the site on both, there will be a CORS error on one of them because the fonts are loaded from the other domain
4. Set the "Always regenerate" checkbox to checked
5. Visit both sites again, the fonts should now load properly
